### PR TITLE
Create new migration for changing date time in timecards table

### DIFF
--- a/TimeCats.web/Controllers/TimeController.cs
+++ b/TimeCats.web/Controllers/TimeController.cs
@@ -98,8 +98,8 @@ namespace TimeCats.Controllers
 
             //  Is time in a date?,  is time out a date?
             //  are hours negative?, is time out a future date?
-            if (!DateTime.TryParse(timecard.timeIn, out timeIn) ||
-                !DateTime.TryParse(timecard.timeOut, out timeOut) ||
+            if (!DateTime.TryParse(timecard.timeIn.ToString(), out timeIn) ||
+                !DateTime.TryParse(timecard.timeOut.ToString(), out timeOut) ||
                 timeOut.CompareTo(timeIn) < 0 ||
                 timeOut > DateTime.Now ||
                 timeIn > DateTime.Now)

--- a/TimeCats.web/Migrations/20200407192310_UpdateTimeCardToUseDateTime.Designer.cs
+++ b/TimeCats.web/Migrations/20200407192310_UpdateTimeCardToUseDateTime.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TimeCats;
@@ -9,9 +10,10 @@ using TimeCats;
 namespace TimeCats.Migrations
 {
     [DbContext(typeof(TimeTrackerContext))]
-    partial class TimeTrackerContextModelSnapshot : ModelSnapshot
+    [Migration("20200407192310_UpdateTimeCardToUseDateTime")]
+    partial class UpdateTimeCardToUseDateTime
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TimeCats.web/Migrations/20200407192310_UpdateTimeCardToUseDateTime.cs
+++ b/TimeCats.web/Migrations/20200407192310_UpdateTimeCardToUseDateTime.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace TimeCats.Migrations
+{
+    public partial class UpdateTimeCardToUseDateTime : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("ALTER TABLE \"TimeCards\" ALTER COLUMN \"timeIn\" TYPE TIMESTAMP USING to_timestamp(\"timeIn\", 'MM/DD/YYYY HH12:MI:SS AM');");
+            migrationBuilder.Sql("ALTER TABLE \"TimeCards\" ALTER COLUMN \"timeOut\" TYPE TIMESTAMP USING to_timestamp(\"timeOut\", 'MM/DD/YYYY HH12:MI:SS AM');");
+            migrationBuilder.Sql("ALTER TABLE \"TimeCards\" ALTER COLUMN \"createdOn\" TYPE TIMESTAMP USING to_timestamp(\"createdOn\", 'MM/DD/YYYY HH12:MI:SS AM');");
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "userID",
+                keyValue: 1,
+                columns: new[] { "Salt", "password" },
+                values: new object[] { new byte[] { 108, 149, 64, 2, 205, 192, 21, 182, 167, 205, 98, 34, 47, 219, 138, 140, 47, 107, 79, 88, 94, 62, 24, 196, 67, 32, 178, 230, 118, 19, 43, 223 }, "9S6d/XZcJoPaEf93LEa7l7LiesmzhGpNIH2Z75JnsBM=" });
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "userID",
+                keyValue: 2,
+                columns: new[] { "Salt", "password" },
+                values: new object[] { new byte[] { 108, 149, 64, 2, 205, 192, 21, 182, 167, 205, 98, 34, 47, 219, 138, 140, 47, 107, 79, 88, 94, 62, 24, 196, 67, 32, 178, 230, 118, 19, 43, 223 }, "9S6d/XZcJoPaEf93LEa7l7LiesmzhGpNIH2Z75JnsBM=" });
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "userID",
+                keyValue: 3,
+                columns: new[] { "Salt", "password" },
+                values: new object[] { new byte[] { 108, 149, 64, 2, 205, 192, 21, 182, 167, 205, 98, 34, 47, 219, 138, 140, 47, 107, 79, 88, 94, 62, 24, 196, 67, 32, 178, 230, 118, 19, 43, 223 }, "9S6d/XZcJoPaEf93LEa7l7LiesmzhGpNIH2Z75JnsBM=" });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("ALTER TABLE \"TimeCards\" ALTER COLUMN \"timeOut\" TYPE text USING to_char(\"timeOut\", 'MM/DD/YYYY HH12:MI:SS AM');");
+            migrationBuilder.Sql("ALTER TABLE \"TimeCards\" ALTER COLUMN \"timeIn\" TYPE text USING to_char(\"timeIn\", 'MM/DD/YYYY HH12:MI:SS AM');");
+            migrationBuilder.Sql("ALTER TABLE \"TimeCards\" ALTER COLUMN \"createdOn\" TYPE text USING to_char(\"createdOn\", 'MM/DD/YYYY HH12:MI:SS AM');");
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "userID",
+                keyValue: 1,
+                columns: new[] { "Salt", "password" },
+                values: new object[] { new byte[] { 108, 110, 182, 72, 99, 140, 124, 237, 190, 197, 146, 104, 19, 46, 232, 192, 99, 42, 70, 77, 22, 183, 40, 98, 108, 239, 138, 119, 22, 29, 80, 244 }, "490wq6CgXtBoa7zQ0+fZ8oula3VY7n0xBuhEyL43eik=" });
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "userID",
+                keyValue: 2,
+                columns: new[] { "Salt", "password" },
+                values: new object[] { new byte[] { 108, 110, 182, 72, 99, 140, 124, 237, 190, 197, 146, 104, 19, 46, 232, 192, 99, 42, 70, 77, 22, 183, 40, 98, 108, 239, 138, 119, 22, 29, 80, 244 }, "490wq6CgXtBoa7zQ0+fZ8oula3VY7n0xBuhEyL43eik=" });
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "userID",
+                keyValue: 3,
+                columns: new[] { "Salt", "password" },
+                values: new object[] { new byte[] { 108, 110, 182, 72, 99, 140, 124, 237, 190, 197, 146, 104, 19, 46, 232, 192, 99, 42, 70, 77, 22, 183, 40, 98, 108, 239, 138, 119, 22, 29, 80, 244 }, "490wq6CgXtBoa7zQ0+fZ8oula3VY7n0xBuhEyL43eik=" });
+        }
+    }
+}

--- a/TimeCats.web/Migrations/20200409030243_UpdateTimeCardToUseDateTime.Designer.cs
+++ b/TimeCats.web/Migrations/20200409030243_UpdateTimeCardToUseDateTime.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TimeCats;
@@ -9,9 +10,10 @@ using TimeCats;
 namespace TimeCats.Migrations
 {
     [DbContext(typeof(TimeTrackerContext))]
-    partial class TimeTrackerContextModelSnapshot : ModelSnapshot
+    [Migration("20200409030243_UpdateTimeCardToUseDateTime")]
+    partial class UpdateTimeCardToUseDateTime
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -133,8 +135,9 @@ namespace TimeCats.Migrations
                         .HasColumnType("integer")
                         .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
 
-                    b.Property<DateTime>("createdOn")
-                        .HasColumnType("timestamp without time zone");
+                    b.Property<string>("createdOn")
+                        .IsRequired()
+                        .HasColumnType("text");
 
                     b.Property<string>("description")
                         .IsRequired()
@@ -143,11 +146,13 @@ namespace TimeCats.Migrations
                     b.Property<int>("groupID")
                         .HasColumnType("integer");
 
-                    b.Property<DateTime>("timeIn")
-                        .HasColumnType("timestamp without time zone");
+                    b.Property<string>("timeIn")
+                        .IsRequired()
+                        .HasColumnType("text");
 
-                    b.Property<DateTime?>("timeOut")
-                        .HasColumnType("timestamp without time zone");
+                    b.Property<string>("timeOut")
+                        .IsRequired()
+                        .HasColumnType("text");
 
                     b.Property<int>("userID")
                         .HasColumnType("integer");
@@ -205,33 +210,33 @@ namespace TimeCats.Migrations
                         new
                         {
                             userID = 1,
-                            Salt = new byte[] { 221, 146, 85, 13, 248, 184, 150, 167, 115, 254, 166, 67, 39, 121, 95, 249, 45, 14, 105, 190, 117, 30, 25, 126, 95, 82, 97, 77, 16, 192, 235, 91 },
+                            Salt = new byte[] { 106, 171, 87, 41, 99, 19, 102, 208, 212, 61, 201, 0, 71, 229, 253, 207, 249, 70, 58, 212, 65, 3, 135, 0, 58, 14, 96, 192, 218, 86, 128, 82 },
                             firstName = "Adam",
                             isActive = true,
                             lastName = "Admin",
-                            password = "sjTWQzBCp7jMCGR142G/jdM0v8ocp9NGmexUz6FTSjc=",
+                            password = "t3nJz5u8ykHpMK/tiinD+P1OhurXJf92ssXxDTE7vRc=",
                             type = 'A',
                             username = "Admin"
                         },
                         new
                         {
                             userID = 2,
-                            Salt = new byte[] { 221, 146, 85, 13, 248, 184, 150, 167, 115, 254, 166, 67, 39, 121, 95, 249, 45, 14, 105, 190, 117, 30, 25, 126, 95, 82, 97, 77, 16, 192, 235, 91 },
+                            Salt = new byte[] { 106, 171, 87, 41, 99, 19, 102, 208, 212, 61, 201, 0, 71, 229, 253, 207, 249, 70, 58, 212, 65, 3, 135, 0, 58, 14, 96, 192, 218, 86, 128, 82 },
                             firstName = "Steve",
                             isActive = true,
                             lastName = "Jobs",
-                            password = "sjTWQzBCp7jMCGR142G/jdM0v8ocp9NGmexUz6FTSjc=",
+                            password = "t3nJz5u8ykHpMK/tiinD+P1OhurXJf92ssXxDTE7vRc=",
                             type = 'I',
                             username = "Instructor"
                         },
                         new
                         {
                             userID = 3,
-                            Salt = new byte[] { 221, 146, 85, 13, 248, 184, 150, 167, 115, 254, 166, 67, 39, 121, 95, 249, 45, 14, 105, 190, 117, 30, 25, 126, 95, 82, 97, 77, 16, 192, 235, 91 },
+                            Salt = new byte[] { 106, 171, 87, 41, 99, 19, 102, 208, 212, 61, 201, 0, 71, 229, 253, 207, 249, 70, 58, 212, 65, 3, 135, 0, 58, 14, 96, 192, 218, 86, 128, 82 },
                             firstName = "Normal",
                             isActive = true,
                             lastName = "User",
-                            password = "sjTWQzBCp7jMCGR142G/jdM0v8ocp9NGmexUz6FTSjc=",
+                            password = "t3nJz5u8ykHpMK/tiinD+P1OhurXJf92ssXxDTE7vRc=",
                             type = 'S',
                             username = "User"
                         });

--- a/TimeCats.web/Migrations/20200409030243_UpdateTimeCardToUseDateTime.cs
+++ b/TimeCats.web/Migrations/20200409030243_UpdateTimeCardToUseDateTime.cs
@@ -7,8 +7,8 @@ namespace TimeCats.Migrations
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.Sql("ALTER TABLE \"TimeCards\" ALTER COLUMN \"timeIn\" TYPE TIMESTAMP USING to_timestamp(\"timeIn\", 'MM/DD/YYYY HH12:MI:SS AM');");
-            migrationBuilder.Sql("ALTER TABLE \"TimeCards\" ALTER COLUMN \"timeOut\" TYPE TIMESTAMP USING to_timestamp(\"timeOut\", 'MM/DD/YYYY HH12:MI:SS AM');");
+            migrationBuilder.Sql("ALTER TABLE \"TimeCards\" ALTER COLUMN \"timeIn\" TYPE TIMESTAMP USING to_timestamp(\"timeIn\", 'MM/DD/YYYY HH12:MI AM');");
+            migrationBuilder.Sql("ALTER TABLE \"TimeCards\" ALTER COLUMN \"timeOut\" TYPE TIMESTAMP USING to_timestamp(\"timeOut\", 'MM/DD/YYYY HH12:MI AM');");
             migrationBuilder.Sql("ALTER TABLE \"TimeCards\" ALTER COLUMN \"createdOn\" TYPE TIMESTAMP USING to_timestamp(\"createdOn\", 'MM/DD/YYYY HH12:MI:SS AM');");
 
             migrationBuilder.UpdateData(
@@ -16,29 +16,29 @@ namespace TimeCats.Migrations
                 keyColumn: "userID",
                 keyValue: 1,
                 columns: new[] { "Salt", "password" },
-                values: new object[] { new byte[] { 108, 149, 64, 2, 205, 192, 21, 182, 167, 205, 98, 34, 47, 219, 138, 140, 47, 107, 79, 88, 94, 62, 24, 196, 67, 32, 178, 230, 118, 19, 43, 223 }, "9S6d/XZcJoPaEf93LEa7l7LiesmzhGpNIH2Z75JnsBM=" });
+                values: new object[] { new byte[] { 106, 171, 87, 41, 99, 19, 102, 208, 212, 61, 201, 0, 71, 229, 253, 207, 249, 70, 58, 212, 65, 3, 135, 0, 58, 14, 96, 192, 218, 86, 128, 82 }, "t3nJz5u8ykHpMK/tiinD+P1OhurXJf92ssXxDTE7vRc=" });
 
             migrationBuilder.UpdateData(
                 table: "Users",
                 keyColumn: "userID",
                 keyValue: 2,
                 columns: new[] { "Salt", "password" },
-                values: new object[] { new byte[] { 108, 149, 64, 2, 205, 192, 21, 182, 167, 205, 98, 34, 47, 219, 138, 140, 47, 107, 79, 88, 94, 62, 24, 196, 67, 32, 178, 230, 118, 19, 43, 223 }, "9S6d/XZcJoPaEf93LEa7l7LiesmzhGpNIH2Z75JnsBM=" });
+                values: new object[] { new byte[] { 106, 171, 87, 41, 99, 19, 102, 208, 212, 61, 201, 0, 71, 229, 253, 207, 249, 70, 58, 212, 65, 3, 135, 0, 58, 14, 96, 192, 218, 86, 128, 82 }, "t3nJz5u8ykHpMK/tiinD+P1OhurXJf92ssXxDTE7vRc=" });
 
             migrationBuilder.UpdateData(
                 table: "Users",
                 keyColumn: "userID",
                 keyValue: 3,
                 columns: new[] { "Salt", "password" },
-                values: new object[] { new byte[] { 108, 149, 64, 2, 205, 192, 21, 182, 167, 205, 98, 34, 47, 219, 138, 140, 47, 107, 79, 88, 94, 62, 24, 196, 67, 32, 178, 230, 118, 19, 43, 223 }, "9S6d/XZcJoPaEf93LEa7l7LiesmzhGpNIH2Z75JnsBM=" });
+                values: new object[] { new byte[] { 106, 171, 87, 41, 99, 19, 102, 208, 212, 61, 201, 0, 71, 229, 253, 207, 249, 70, 58, 212, 65, 3, 135, 0, 58, 14, 96, 192, 218, 86, 128, 82 }, "t3nJz5u8ykHpMK/tiinD+P1OhurXJf92ssXxDTE7vRc=" });
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.Sql("ALTER TABLE \"TimeCards\" ALTER COLUMN \"timeOut\" TYPE text USING to_char(\"timeOut\", 'MM/DD/YYYY HH12:MI:SS AM');");
-            migrationBuilder.Sql("ALTER TABLE \"TimeCards\" ALTER COLUMN \"timeIn\" TYPE text USING to_char(\"timeIn\", 'MM/DD/YYYY HH12:MI:SS AM');");
+            migrationBuilder.Sql("ALTER TABLE \"TimeCards\" ALTER COLUMN \"timeIn\" TYPE text USING to_char(\"timeIn\", 'MM/DD/YYYY HH12:MI AM');");
+            migrationBuilder.Sql("ALTER TABLE \"TimeCards\" ALTER COLUMN \"timeOut\" TYPE text USING to_char(\"timeOut\", 'MM/DD/YYYY HH12:MI AM');");
             migrationBuilder.Sql("ALTER TABLE \"TimeCards\" ALTER COLUMN \"createdOn\" TYPE text USING to_char(\"createdOn\", 'MM/DD/YYYY HH12:MI:SS AM');");
-
+            
             migrationBuilder.UpdateData(
                 table: "Users",
                 keyColumn: "userID",

--- a/TimeCats.web/Migrations/20200409030643_UpdateTimeCardTimeOutToBeNullable.Designer.cs
+++ b/TimeCats.web/Migrations/20200409030643_UpdateTimeCardTimeOutToBeNullable.Designer.cs
@@ -10,8 +10,8 @@ using TimeCats;
 namespace TimeCats.Migrations
 {
     [DbContext(typeof(TimeTrackerContext))]
-    [Migration("20200407192310_UpdateTimeCardToUseDateTime")]
-    partial class UpdateTimeCardToUseDateTime
+    [Migration("20200409030643_UpdateTimeCardTimeOutToBeNullable")]
+    partial class UpdateTimeCardTimeOutToBeNullable
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -207,33 +207,33 @@ namespace TimeCats.Migrations
                         new
                         {
                             userID = 1,
-                            Salt = new byte[] { 108, 149, 64, 2, 205, 192, 21, 182, 167, 205, 98, 34, 47, 219, 138, 140, 47, 107, 79, 88, 94, 62, 24, 196, 67, 32, 178, 230, 118, 19, 43, 223 },
+                            Salt = new byte[] { 221, 146, 85, 13, 248, 184, 150, 167, 115, 254, 166, 67, 39, 121, 95, 249, 45, 14, 105, 190, 117, 30, 25, 126, 95, 82, 97, 77, 16, 192, 235, 91 },
                             firstName = "Adam",
                             isActive = true,
                             lastName = "Admin",
-                            password = "9S6d/XZcJoPaEf93LEa7l7LiesmzhGpNIH2Z75JnsBM=",
+                            password = "sjTWQzBCp7jMCGR142G/jdM0v8ocp9NGmexUz6FTSjc=",
                             type = 'A',
                             username = "Admin"
                         },
                         new
                         {
                             userID = 2,
-                            Salt = new byte[] { 108, 149, 64, 2, 205, 192, 21, 182, 167, 205, 98, 34, 47, 219, 138, 140, 47, 107, 79, 88, 94, 62, 24, 196, 67, 32, 178, 230, 118, 19, 43, 223 },
+                            Salt = new byte[] { 221, 146, 85, 13, 248, 184, 150, 167, 115, 254, 166, 67, 39, 121, 95, 249, 45, 14, 105, 190, 117, 30, 25, 126, 95, 82, 97, 77, 16, 192, 235, 91 },
                             firstName = "Steve",
                             isActive = true,
                             lastName = "Jobs",
-                            password = "9S6d/XZcJoPaEf93LEa7l7LiesmzhGpNIH2Z75JnsBM=",
+                            password = "sjTWQzBCp7jMCGR142G/jdM0v8ocp9NGmexUz6FTSjc=",
                             type = 'I',
                             username = "Instructor"
                         },
                         new
                         {
                             userID = 3,
-                            Salt = new byte[] { 108, 149, 64, 2, 205, 192, 21, 182, 167, 205, 98, 34, 47, 219, 138, 140, 47, 107, 79, 88, 94, 62, 24, 196, 67, 32, 178, 230, 118, 19, 43, 223 },
+                            Salt = new byte[] { 221, 146, 85, 13, 248, 184, 150, 167, 115, 254, 166, 67, 39, 121, 95, 249, 45, 14, 105, 190, 117, 30, 25, 126, 95, 82, 97, 77, 16, 192, 235, 91 },
                             firstName = "Normal",
                             isActive = true,
                             lastName = "User",
-                            password = "9S6d/XZcJoPaEf93LEa7l7LiesmzhGpNIH2Z75JnsBM=",
+                            password = "sjTWQzBCp7jMCGR142G/jdM0v8ocp9NGmexUz6FTSjc=",
                             type = 'S',
                             username = "User"
                         });

--- a/TimeCats.web/Migrations/20200409030643_UpdateTimeCardTimeOutToBeNullable.cs
+++ b/TimeCats.web/Migrations/20200409030643_UpdateTimeCardTimeOutToBeNullable.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace TimeCats.Migrations
+{
+    public partial class UpdateTimeCardTimeOutToBeNullable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "timeOut",
+                table: "TimeCards",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "timeIn",
+                table: "TimeCards",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "createdOn",
+                table: "TimeCards",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "userID",
+                keyValue: 1,
+                columns: new[] { "Salt", "password" },
+                values: new object[] { new byte[] { 221, 146, 85, 13, 248, 184, 150, 167, 115, 254, 166, 67, 39, 121, 95, 249, 45, 14, 105, 190, 117, 30, 25, 126, 95, 82, 97, 77, 16, 192, 235, 91 }, "sjTWQzBCp7jMCGR142G/jdM0v8ocp9NGmexUz6FTSjc=" });
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "userID",
+                keyValue: 2,
+                columns: new[] { "Salt", "password" },
+                values: new object[] { new byte[] { 221, 146, 85, 13, 248, 184, 150, 167, 115, 254, 166, 67, 39, 121, 95, 249, 45, 14, 105, 190, 117, 30, 25, 126, 95, 82, 97, 77, 16, 192, 235, 91 }, "sjTWQzBCp7jMCGR142G/jdM0v8ocp9NGmexUz6FTSjc=" });
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "userID",
+                keyValue: 3,
+                columns: new[] { "Salt", "password" },
+                values: new object[] { new byte[] { 221, 146, 85, 13, 248, 184, 150, 167, 115, 254, 166, 67, 39, 121, 95, 249, 45, 14, 105, 190, 117, 30, 25, 126, 95, 82, 97, 77, 16, 192, 235, 91 }, "sjTWQzBCp7jMCGR142G/jdM0v8ocp9NGmexUz6FTSjc=" });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "timeOut",
+                table: "TimeCards",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "timeIn",
+                table: "TimeCards",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(DateTime));
+
+            migrationBuilder.AlterColumn<string>(
+                name: "createdOn",
+                table: "TimeCards",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(DateTime));
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "userID",
+                keyValue: 1,
+                columns: new[] { "Salt", "password" },
+                values: new object[] { new byte[] { 106, 171, 87, 41, 99, 19, 102, 208, 212, 61, 201, 0, 71, 229, 253, 207, 249, 70, 58, 212, 65, 3, 135, 0, 58, 14, 96, 192, 218, 86, 128, 82 }, "t3nJz5u8ykHpMK/tiinD+P1OhurXJf92ssXxDTE7vRc=" });
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "userID",
+                keyValue: 2,
+                columns: new[] { "Salt", "password" },
+                values: new object[] { new byte[] { 106, 171, 87, 41, 99, 19, 102, 208, 212, 61, 201, 0, 71, 229, 253, 207, 249, 70, 58, 212, 65, 3, 135, 0, 58, 14, 96, 192, 218, 86, 128, 82 }, "t3nJz5u8ykHpMK/tiinD+P1OhurXJf92ssXxDTE7vRc=" });
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "userID",
+                keyValue: 3,
+                columns: new[] { "Salt", "password" },
+                values: new object[] { new byte[] { 106, 171, 87, 41, 99, 19, 102, 208, 212, 61, 201, 0, 71, 229, 253, 207, 249, 70, 58, 212, 65, 3, 135, 0, 58, 14, 96, 192, 218, 86, 128, 82 }, "t3nJz5u8ykHpMK/tiinD+P1OhurXJf92ssXxDTE7vRc=" });
+        }
+    }
+}

--- a/TimeCats.web/Models/TimeCard.cs
+++ b/TimeCats.web/Models/TimeCard.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace TimeCats.Models
@@ -12,16 +13,15 @@ namespace TimeCats.Models
         public double hours { get; set; } //TODO: This should probably be a decimal
         
         [Required]
-        public string timeIn { get; set; } //TODO: Convert to DATETIME
+        public DateTime timeIn { get; set; }
         
-        [Required]
-        public string timeOut { get; set; } //TODO: Convert to DATETIME
+        public DateTime? timeOut { get; set; }
         
         [NotMapped]
         public bool isEdited { get; set; }
         
         [Required]
-        public string createdOn { get; set; } //TODO: Convert this to a DATETIME2
+        public DateTime createdOn { get; set; }
         
         [Required]
         public int userID { get; set; }


### PR DESCRIPTION
Creates a new migration that will change the strings to datetimes (timestamps) in the postgres database.

`We still need to verify that the timestamps are in the correct format going forward and backwards`
@JonathanGast is this something that you can confirm? We basically just need to make sure the up function is grabbing the correct formatted data from the database (add a new record and for each date time column then make sure the format is correctly corresponded) then we need to do the opposite going down.

[to_timestamp documentation](https://www.postgresqltutorial.com/postgresql-to_timestamp/)
[to_char documentation](https://www.postgresqltutorial.com/postgresql-to_char/)